### PR TITLE
api client

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -7,9 +7,6 @@
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
     "@reduxjs/toolkit": "^1.3.5",
-    "@testing-library/jest-dom": "^5.5.0",
-    "@testing-library/react": "^10.0.4",
-    "@testing-library/user-event": "^10.1.0",
     "emotion-theming": "^10.0.27",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
@@ -46,6 +43,9 @@
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
     "@types/react-redux": "^7.1.8",
+    "@testing-library/jest-dom": "^5.5.0",
+    "@testing-library/react": "^10.0.4",
+    "@testing-library/user-event": "^10.1.0",
     "typescript": "^3.8.3"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -6,6 +6,7 @@
     "@chakra-ui/core": "^0.8.0",
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
+    "@quizthing/common": "^0.0.0",
     "@reduxjs/toolkit": "^1.3.5",
     "axios": "^0.19.2",
     "emotion-theming": "^10.0.27",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -7,6 +7,7 @@
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
     "@reduxjs/toolkit": "^1.3.5",
+    "axios": "^0.19.2",
     "emotion-theming": "^10.0.27",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
@@ -38,14 +39,15 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^5.5.0",
+    "@testing-library/react": "^10.0.4",
+    "@testing-library/user-event": "^10.1.0",
     "@types/jest": "^25.2.1",
     "@types/node": "^14.0.1",
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
     "@types/react-redux": "^7.1.8",
-    "@testing-library/jest-dom": "^5.5.0",
-    "@testing-library/react": "^10.0.4",
-    "@testing-library/user-event": "^10.1.0",
+    "axios-mock-adapter": "^1.18.1",
     "typescript": "^3.8.3"
   }
 }

--- a/packages/client/src/services/__test__/api.test.ts
+++ b/packages/client/src/services/__test__/api.test.ts
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { ApiClient, Api } from '../api';
+
+const mock = new MockAdapter(axios);
+
+describe('ApiClient tests', () => {
+  let api: Api;
+
+  beforeEach(() => {
+    api = new ApiClient();
+  });
+
+  afterEach(() => {
+    mock.resetHistory();
+  });
+
+  test('get returning 200 to no base executes correctly', async () => {
+    mock.onGet('/').reply(200);
+    await api.get<any>('/');
+
+    Object.entries(mock.history)
+      .filter(([key, _]) => key !== 'get')
+      .forEach(([_, val]) => {
+        expect(val).toHaveLength(0);
+      });
+
+    expect(mock.history['get']).toHaveLength(1);
+  });
+});

--- a/packages/client/src/services/api.ts
+++ b/packages/client/src/services/api.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
+import type { Nullable } from '@quizthing/common';
 
 export interface Api {
   get: <T>(url: string) => Promise<T>;
@@ -6,8 +7,6 @@ export interface Api {
   put: <T>(url: string, body: any) => Promise<T>;
   patch: <T>(url: string, body: any) => Promise<T>;
 }
-
-type Nullable<T> = T | null;
 
 const defaultHeaders = {
   'Content-Type': 'application/json',

--- a/packages/client/src/services/api.ts
+++ b/packages/client/src/services/api.ts
@@ -1,0 +1,61 @@
+import axios, { AxiosInstance } from 'axios';
+
+export interface Api {
+  get: <T>(url: string) => Promise<T>;
+  post: <T>(url: string, body: any) => Promise<T>;
+  put: <T>(url: string, body: any) => Promise<T>;
+  patch: <T>(url: string, body: any) => Promise<T>;
+}
+
+type Nullable<T> = T | null;
+
+const defaultHeaders = {
+  'Content-Type': 'application/json',
+};
+
+export class ApiClient implements Api {
+  readonly #instance: AxiosInstance;
+
+  #authToken: Nullable<string> = null;
+
+  constructor() {
+    const instance = axios.create({
+      baseURL: '',
+      headers: defaultHeaders,
+    });
+
+    instance.interceptors.request.use((conf) => {
+      if (this.#authToken) {
+        conf.headers.Authorization = `Bearer ${this.#authToken}`;
+      }
+      return conf;
+    });
+
+    this.#instance = instance;
+  }
+
+  get = async <T>(url: string): Promise<T> => {
+    const response = await this.#instance.get<T>(url);
+    return response.data;
+  };
+
+  post = async <T>(url: string, body: any): Promise<T> => {
+    axios.post('');
+    const response = await this.#instance.post<T>(url, body);
+    return response.data;
+  };
+
+  put = async <T>(url: string, body: any): Promise<T> => {
+    const response = await this.#instance.put<T>(url, body);
+    return response.data;
+  };
+
+  patch = async <T>(url: string, body: any): Promise<T> => {
+    const response = await this.#instance.patch<T>(url, body);
+    return response.data;
+  };
+
+  setAuthToken = (shit: Nullable<string>) => {
+    this.#authToken = shit;
+  };
+}

--- a/packages/client/src/services/api.ts
+++ b/packages/client/src/services/api.ts
@@ -7,7 +7,7 @@ export interface Api {
   put: <T>(url: string, body: any) => Promise<T>;
   patch: <T>(url: string, body: any) => Promise<T>;
   delete: <T>(url: string, body: any) => Promise<T>;
-  setAuthToken: (shit: Nullable<string>) => void;
+  setAuthToken: (authToken: Nullable<string>) => void;
 }
 
 enum HttpStatus {
@@ -28,8 +28,16 @@ const defaultHeaders = {
   'Content-Type': 'application/json',
 };
 
+/**
+ * Promise fulfilled handler for api requests.
+ * @param res
+ */
 const onFulfilled = (res: AxiosResponse) => res;
 
+/**
+ * Promise rejected handler for api requests.
+ * @param err
+ */
 const onRejected = (err: any) => {
   if (err.response.status === 401) {
     // throw an error?
@@ -86,7 +94,7 @@ export class ApiClient implements Api {
     return response.data;
   };
 
-  setAuthToken = (shit: Nullable<string>) => {
-    this.#authToken = shit;
+  setAuthToken = (authToken: Nullable<string>) => {
+    this.#authToken = authToken;
   };
 }

--- a/packages/client/src/services/api.ts
+++ b/packages/client/src/services/api.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance } from 'axios';
+import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import type { Nullable } from '@quizthing/common';
 
 export interface Api {
@@ -11,6 +11,16 @@ export interface Api {
 
 const defaultHeaders = {
   'Content-Type': 'application/json',
+};
+
+const onFulfilled = (res: AxiosResponse) => res;
+
+const onRejected = (err: any) => {
+  if (err.response.status === 401) {
+    // throw an error?
+    return;
+  }
+  return Promise.reject(err);
 };
 
 export class ApiClient implements Api {
@@ -30,6 +40,8 @@ export class ApiClient implements Api {
       }
       return conf;
     });
+
+    instance.interceptors.response.use(onFulfilled, onRejected);
 
     this.#instance = instance;
   }

--- a/packages/client/src/services/api.ts
+++ b/packages/client/src/services/api.ts
@@ -6,6 +6,7 @@ export interface Api {
   post: <T>(url: string, body: any) => Promise<T>;
   put: <T>(url: string, body: any) => Promise<T>;
   patch: <T>(url: string, body: any) => Promise<T>;
+  delete: <T>(url: string, body: any) => Promise<T>;
   setAuthToken: (shit: Nullable<string>) => void;
 }
 
@@ -63,6 +64,11 @@ export class ApiClient implements Api {
 
   patch = async <T>(url: string, body: any): Promise<T> => {
     const response = await this.#instance.patch<T>(url, body);
+    return response.data;
+  };
+
+  delete = async <T>(url: string, body: any): Promise<T> => {
+    const response = await this.#instance.delete<T>(url, body);
     return response.data;
   };
 

--- a/packages/client/src/services/api.ts
+++ b/packages/client/src/services/api.ts
@@ -10,6 +10,20 @@ export interface Api {
   setAuthToken: (shit: Nullable<string>) => void;
 }
 
+enum HttpStatus {
+  Ok = 200,
+  Created = 201,
+  NoContent = 204,
+  BadRequest = 400,
+  Unauthorized = 401,
+  Forbidden = 403,
+  NotFound = 404,
+  Conflict = 409,
+  InternalServerError = 500,
+  BadGateway = 502,
+  ServiceUnavailable = 503,
+}
+
 const defaultHeaders = {
   'Content-Type': 'application/json',
 };

--- a/packages/client/src/services/api.ts
+++ b/packages/client/src/services/api.ts
@@ -6,6 +6,7 @@ export interface Api {
   post: <T>(url: string, body: any) => Promise<T>;
   put: <T>(url: string, body: any) => Promise<T>;
   patch: <T>(url: string, body: any) => Promise<T>;
+  setAuthToken: (shit: Nullable<string>) => void;
 }
 
 const defaultHeaders = {
@@ -39,7 +40,6 @@ export class ApiClient implements Api {
   };
 
   post = async <T>(url: string, body: any): Promise<T> => {
-    axios.post('');
     const response = await this.#instance.post<T>(url, body);
     return response.data;
   };

--- a/packages/client/yarn.lock
+++ b/packages/client/yarn.lock
@@ -2510,6 +2510,21 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
   integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
 
+axios-mock-adapter@^1.18.1:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.18.1.tgz#a2ba2638ef513d954793f96bde3e26bd4a1b7940"
+  integrity sha512-kFBZsG1Ma5yxjRGHq5KuuL55mPb7WzFULhypquEhzPg8SH5CXICb+qwC2CCA5u+GQVpiqGPwKSRkd3mBCs6gdw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    is-buffer "^2.0.3"
+
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 axobject-query@^2.0.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.1.2.tgz#2bdffc0371e643e5f03ba99065d5179b9ca79799"
@@ -3887,6 +3902,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^3.0.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -4983,6 +5005,13 @@ focus-lock@^0.6.7:
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.8.tgz#61985fadfa92f02f2ee1d90bc738efaf7f3c9f46"
   integrity sha512-vkHTluRCoq9FcsrldC0ulQHiyBYgVJB2CX53I8r0nTC6KnEij7Of0jpBspjt3/CuNb6fyoj3aOh9J2HgQUM0og==
 
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
 follow-redirects@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.11.0.tgz#afa14f08ba12a52963140fe43212658897bc0ecb"
@@ -5846,6 +5875,11 @@ is-buffer@^1.0.2, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
+  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-callable@^1.1.4, is-callable@^1.1.5:
   version "1.1.5"

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,0 +1,11 @@
+# `@quizthing/common`
+
+> TODO: description
+
+## Usage
+
+```
+const common = require('@quizthing/common');
+
+// TODO: DEMONSTRATE API
+```

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@quizthing/common",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Common entities between client and server",
+  "author": "Aaron Osteraas <aaron.osteraas@gmail.com>",
+  "homepage": "https://github.com/aosteraas/quizthing#readme",
+  "license": "ISC",
+  "main": "src/index.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "__tests__"
+  },
+  "files": [
+    "lib"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aosteraas/quizthing.git"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  },
+  "bugs": {
+    "url": "https://github.com/aosteraas/quizthing/issues"
+  }
+}

--- a/packages/common/src/Nullable.ts
+++ b/packages/common/src/Nullable.ts
@@ -1,0 +1,1 @@
+export type Nullable<T> = T | null;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,0 +1,1 @@
+export * from './Nullable';


### PR DESCRIPTION
Pretty much what it says on the box. 

Wound up going with Axios instead of native fetch as it's a little nicer to use and means less boilerplate code floating around. The ApiClient class implements the interface so we can more easily mock it in future when testing other services that use it. 

There are a few items to be aware of

- The class instantiates an instance of the axios client so we can have a configured instance of it in the class
- Auth token is added to every request, if it exists, using a request interceptor
- A response interceptor is applied too, the fulfilled interceptor is pretty useless, the rejected is but only for now, once we decide how we want to handle errors
- The methods have a generic argument so we can make use of type safety the whole way down

Otherwise, I added another lerna module `@quizthing/common` and jammed a utility type in there, if we want to share code between client and server, we can put it there.