### PR TITLE
Create and Delete Quiz

### DIFF
--- a/packages/client/src/services/api.ts
+++ b/packages/client/src/services/api.ts
@@ -1,6 +1,5 @@
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import type { Nullable } from '@quizthing/common';
-import { CLIENT_RENEG_LIMIT } from 'tls';
 
 export interface Api {
   get: <T>(url: string) => Promise<T>;

--- a/packages/server/src/auth/user.entity.ts
+++ b/packages/server/src/auth/user.entity.ts
@@ -4,8 +4,10 @@ import {
   Unique,
   PrimaryGeneratedColumn,
   Column,
+  ManyToOne,
 } from 'typeorm';
 import * as bcrypt from 'bcrypt';
+import { Quiz } from '../quiz/quiz.entity';
 
 @Entity()
 @Unique(['username'])
@@ -25,6 +27,9 @@ export class User extends BaseEntity {
 
   @Column()
   salt: string;
+
+  @ManyToOne(() => Quiz, (quiz) => quiz.user)
+  quizzes: Quiz[];
 
   async validatePassword(password: string): Promise<boolean> {
     const hash = await bcrypt.hash(password, this.salt);

--- a/packages/server/src/quiz/__snapshots__/quiz.service.spec.ts.snap
+++ b/packages/server/src/quiz/__snapshots__/quiz.service.spec.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`QuizService createQuiz returns a new quiz without the user 1`] = `
+Object {
+  "created": 2020-06-24T09:42:28.004Z,
+  "desc": "something",
+  "id": 1,
+  "questions": Array [],
+  "title": "some quiz",
+  "userId": 1,
+}
+`;

--- a/packages/server/src/quiz/dto/create-quiz.dto.ts
+++ b/packages/server/src/quiz/dto/create-quiz.dto.ts
@@ -3,4 +3,6 @@ import { IsNotEmpty } from 'class-validator';
 export class CreateQuizDto {
   @IsNotEmpty()
   title: string;
+
+  description?: string;
 }

--- a/packages/server/src/quiz/quiz.controller.ts
+++ b/packages/server/src/quiz/quiz.controller.ts
@@ -1,12 +1,23 @@
-import { Controller, Post } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  UsePipes,
+  ValidationPipe,
+  Body,
+} from '@nestjs/common';
 import { QuizService } from './quiz.service';
+import { GetUser } from '../auth/get-user-decorator';
+import { User } from '../auth/user.entity';
+import { CreateQuizDto } from './dto/create-quiz.dto';
 
 @Controller('quiz')
 export class QuizController {
   constructor(private readonly quizService: QuizService) {}
 
-  @Post('/')
-  async create() {
-    return await this.quizService.createQuiz();
+  @Post()
+  @UsePipes(ValidationPipe)
+  async create(@Body() createQuizDto: CreateQuizDto, @GetUser() user: User) {
+    const quiz = await this.quizService.createQuiz();
+    return quiz;
   }
 }

--- a/packages/server/src/quiz/quiz.controller.ts
+++ b/packages/server/src/quiz/quiz.controller.ts
@@ -4,6 +4,11 @@ import {
   UsePipes,
   ValidationPipe,
   Body,
+  Delete,
+  Param,
+  ParseIntPipe,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import { QuizService } from './quiz.service';
 import { GetUser } from '../auth/get-user-decorator';
@@ -17,7 +22,16 @@ export class QuizController {
   @Post()
   @UsePipes(ValidationPipe)
   async create(@Body() createQuizDto: CreateQuizDto, @GetUser() user: User) {
-    const quiz = await this.quizService.createQuiz();
+    const quiz = await this.quizService.createQuiz(createQuizDto, user);
     return quiz;
+  }
+
+  @Delete('/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteQuiz(
+    @Param('id', ParseIntPipe) id: number,
+    @GetUser() user: User,
+  ) {
+    return await this.quizService.deleteQuiz(id, user);
   }
 }

--- a/packages/server/src/quiz/quiz.entity.ts
+++ b/packages/server/src/quiz/quiz.entity.ts
@@ -5,6 +5,7 @@ import {
   Column,
   OneToMany,
   ManyToOne,
+  CreateDateColumn,
 } from 'typeorm';
 import { Question } from '../question/question.entity';
 import { User } from '../auth/user.entity';
@@ -17,12 +18,18 @@ export class Quiz extends BaseEntity {
   @Column()
   title: string;
 
-  @Column({ type: 'timestamptz' })
-  created: string;
+  @Column()
+  description: string;
+
+  @CreateDateColumn()
+  created: Date;
 
   @OneToMany(() => Question, (question) => question.question, { eager: false })
   questions: Question[];
 
   @ManyToOne(() => User, (user) => user.quizzes)
   user: User;
+
+  @Column()
+  userId: number;
 }

--- a/packages/server/src/quiz/quiz.entity.ts
+++ b/packages/server/src/quiz/quiz.entity.ts
@@ -4,8 +4,10 @@ import {
   PrimaryGeneratedColumn,
   Column,
   OneToMany,
+  ManyToOne,
 } from 'typeorm';
 import { Question } from '../question/question.entity';
+import { User } from '../auth/user.entity';
 
 @Entity()
 export class Quiz extends BaseEntity {
@@ -20,4 +22,7 @@ export class Quiz extends BaseEntity {
 
   @OneToMany(() => Question, (question) => question.question, { eager: false })
   questions: Question[];
+
+  @ManyToOne(() => User, (user) => user.quizzes)
+  user: User;
 }

--- a/packages/server/src/quiz/quiz.repository.ts
+++ b/packages/server/src/quiz/quiz.repository.ts
@@ -8,7 +8,9 @@ export class QuizRepository extends Repository<Quiz> {
   async createQuiz(createQuizDto: CreateQuizDto, user: User) {
     const quiz = new Quiz();
     quiz.title = createQuizDto.title;
+    quiz.description = createQuizDto.description ?? '';
     quiz.user = user;
+
     await quiz.save();
 
     delete quiz.user;

--- a/packages/server/src/quiz/quiz.repository.ts
+++ b/packages/server/src/quiz/quiz.repository.ts
@@ -1,15 +1,18 @@
 import { EntityRepository, Repository } from 'typeorm';
 import { Quiz } from './quiz.entity';
 import { CreateQuizDto } from './dto/create-quiz.dto';
+import { User } from '../auth/user.entity';
 
 @EntityRepository(Quiz)
 export class QuizRepository extends Repository<Quiz> {
-  createQuiz = async (createQuizDto: CreateQuizDto) => {
+  async createQuiz(createQuizDto: CreateQuizDto, user: User) {
     const quiz = new Quiz();
     quiz.title = createQuizDto.title;
-
+    quiz.user = user;
     await quiz.save();
 
+    delete quiz.user;
+
     return quiz;
-  };
+  }
 }

--- a/packages/server/src/quiz/quiz.service.spec.ts
+++ b/packages/server/src/quiz/quiz.service.spec.ts
@@ -3,13 +3,16 @@ import { QuizService } from './quiz.service';
 import { QuizRepository } from './quiz.repository';
 import { User } from '../auth/user.entity';
 import { Quiz } from './quiz.entity';
+import { NotFoundException } from '@nestjs/common';
 
 const mockQuizRepository = () => ({
-  //
+  createQuiz: jest.fn(),
+  delete: jest.fn(),
 });
 
 describe('QuizService', () => {
   let service: QuizService;
+  let repository;
   const mockUser = {
     id: 1,
     username: 'testuser',
@@ -26,19 +29,34 @@ describe('QuizService', () => {
     }).compile();
 
     service = module.get<QuizService>(QuizService);
+    repository = module.get<QuizRepository>(QuizRepository);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
-  it('createQuiz returns a nrew quiz without the user', async () => {
-    const createQuizDto = { title: 'some quiz' };
+  it('createQuiz returns a new quiz without the user', async () => {
+    const createQuizDto = { title: 'some quiz', desc: 'something' };
+    const quizEntity = {
+      ...createQuizDto,
+      id: 1,
+      created: new Date('2020-06-24T09:42:28.004Z'),
+      questions: [],
+      userId: mockUser.id,
+    };
+    repository.createQuiz.mockResolvedValue(quizEntity);
     const quiz = await service.createQuiz(createQuizDto, mockUser);
-    expect(quiz).toBeInstanceOf(Quiz);
-    expect(quiz).toMatchInlineSnapshot();
+
+    expect(quiz).toMatchSnapshot();
+    expect(quiz.user).toBeUndefined();
   });
-  it('deleteQuiz', () => {
-    expect(() => service.deleteQuiz()).toThrow();
+  it('deleteQuiz throws not found exception when matching quiz not found', async () => {
+    repository.delete.mockResolvedValue({ affected: 0 });
+    expect(service.deleteQuiz(1, mockUser)).rejects.toThrow(NotFoundException);
+  });
+  it('deleteQuiz returns void when deleting a quiz successfully', async () => {
+    repository.delete.mockResolvedValue({ affected: 1 });
+    expect(service.deleteQuiz(1, mockUser)).resolves.toBeUndefined();
   });
   it('updateQuiz', () => {
     expect(() => service.updateQuiz()).toThrow();

--- a/packages/server/src/quiz/quiz.service.spec.ts
+++ b/packages/server/src/quiz/quiz.service.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { QuizService } from './quiz.service';
 import { QuizRepository } from './quiz.repository';
+import { User } from '../auth/user.entity';
+import { Quiz } from './quiz.entity';
 
 const mockQuizRepository = () => ({
   //
@@ -8,7 +10,13 @@ const mockQuizRepository = () => ({
 
 describe('QuizService', () => {
   let service: QuizService;
-
+  const mockUser = {
+    id: 1,
+    username: 'testuser',
+    email: 'fake@email.com',
+    password: 'fake password',
+    salt: 'some salt',
+  } as User;
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -23,8 +31,11 @@ describe('QuizService', () => {
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
-  it('createQuiz', () => {
-    expect(() => service.createQuiz()).toThrow();
+  it('createQuiz returns a nrew quiz without the user', async () => {
+    const createQuizDto = { title: 'some quiz' };
+    const quiz = await service.createQuiz(createQuizDto, mockUser);
+    expect(quiz).toBeInstanceOf(Quiz);
+    expect(quiz).toMatchInlineSnapshot();
   });
   it('deleteQuiz', () => {
     expect(() => service.deleteQuiz()).toThrow();

--- a/packages/server/src/quiz/quiz.service.ts
+++ b/packages/server/src/quiz/quiz.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotImplementedException } from '@nestjs/common';
+import {
+  Injectable,
+  NotImplementedException,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { QuizRepository } from './quiz.repository';
 import { CreateQuizDto } from './dto/create-quiz.dto';
@@ -16,8 +20,11 @@ export class QuizService {
     return quiz;
   }
 
-  deleteQuiz() {
-    throw new NotImplementedException();
+  async deleteQuiz(id: number, user: User) {
+    const removed = await this.quizRepository.delete({ id, userId: user.id });
+    if (!removed.affected) {
+      throw new NotFoundException();
+    }
   }
 
   updateQuiz() {

--- a/packages/server/src/quiz/quiz.service.ts
+++ b/packages/server/src/quiz/quiz.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, NotImplementedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { QuizRepository } from './quiz.repository';
+import { CreateQuizDto } from './dto/create-quiz.dto';
+import { User } from '../auth/user.entity';
 
 @Injectable()
 export class QuizService {
@@ -9,8 +11,9 @@ export class QuizService {
     private readonly quizRepository: QuizRepository,
   ) {}
 
-  createQuiz() {
-    throw new NotImplementedException();
+  async createQuiz(createQuizDto: CreateQuizDto, user: User) {
+    const quiz = await this.quizRepository.createQuiz(createQuizDto, user);
+    return quiz;
   }
 
   deleteQuiz() {


### PR DESCRIPTION
- Add Relationship between User and Quiz entities
- Add explicit `userId` to Quiz entity
- Change `created` column on Quiz to be autogenerated date
- Get user out of controller and pass through to service and repository
- Specify HTTP Status in delete response to `204`
- Updated CreateQuizDto to have optional description
- Update tests for create and delete cases